### PR TITLE
DF Example Finder Upgrade

### DIFF
--- a/cmd/df_example_finder/main.go
+++ b/cmd/df_example_finder/main.go
@@ -1,43 +1,77 @@
 package main
 
 import (
-	"bufio"
-	"compress/bzip2"
-	"compress/gzip"
 	"fmt"
-	"io"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v2"
 	"os"
+	"plane.watch/lib/logging"
+	"plane.watch/lib/setup"
+	"plane.watch/lib/tracker"
+	"plane.watch/lib/tracker/beast"
 	"plane.watch/lib/tracker/mode_s"
 	"strings"
+	"sync"
 	"time"
 )
 
-func getFileReader(filePath string) (io.Reader, error) {
-	f, err := os.Open(filePath)
+func incoming(c *cli.Context) (chan tracker.Frame, error) {
+	producers, err := setup.HandleSourceFlags(c)
+	log.Info().Int("Num Sources", len(producers)).Send()
 	if nil != err {
 		return nil, err
 	}
-	if strings.HasSuffix(filePath, ".gz") {
-		println("Reading Gzip file")
-		return gzip.NewReader(f)
+	out := make(chan tracker.Frame)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	for _, producer := range producers {
+
+		go func(p tracker.Producer) {
+			wg.Add(1)
+			log.Debug().
+				Bool("Healthy?", p.HealthCheck()).
+				Str("Source", p.String()).
+				Msg("Starting Read from Producer")
+			for e := range p.Listen() {
+				log.Debug().Str("type", e.Type()).Str("event", e.String()).Send()
+				switch e.(type) {
+				case *tracker.FrameEvent:
+					out <- e.(*tracker.FrameEvent).Frame()
+				}
+			}
+			wg.Done()
+		}(producer)
 	}
-	if strings.HasSuffix(filePath, ".bz2") {
-		println("Reading Bzip2 file")
-		return bzip2.NewReader(f), nil
-	}
-	println("Reading plain text file")
-	return f, nil
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		wg.Wait()
+		close(out)
+	}()
+
+	wg.Done()
+	return out, nil
 }
 
-func gatherSamples(filePath string) {
-
-	f, err := getFileReader(filePath)
-
-	if nil != err {
-		println(err)
-		return
+func modeSFrame(iframe tracker.Frame) *mode_s.Frame {
+	if err := iframe.Decode(); nil != err {
+		log.Error().Err(err).Str("frame", fmt.Sprintf("%X", iframe.Raw())).Send()
 	}
-	println("Processing file...")
+	switch iframe.(type) {
+	case *mode_s.Frame:
+		return iframe.(*mode_s.Frame)
+	case *beast.Frame:
+		return iframe.(*beast.Frame).AvrFrame()
+	}
+	return nil
+}
+
+func gatherSamples(c *cli.Context) error {
+	incomingChan, err := incoming(c)
+	if nil != err {
+		return err
+	}
+	log.Info().Msg("Processing...")
 
 	countMap := make(map[byte]uint32)
 	df17Map := make(map[byte]uint32)
@@ -45,13 +79,9 @@ func gatherSamples(filePath string) {
 	samples := make(map[byte][]string)
 	existingSamples := make(map[string]bool)
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		frame, err := mode_s.DecodeString(line, time.Now())
-		if nil != err {
-			println("Error! ", line, err.Error())
+	for iframe := range incomingChan {
+		frame := modeSFrame(iframe)
+		if nil == frame {
 			continue
 		}
 
@@ -73,9 +103,9 @@ func gatherSamples(filePath string) {
 		}
 
 		if len(samples[frame.DownLinkType()]) < 100 {
-			if _, exist := existingSamples[line]; !exist {
-				samples[frame.DownLinkType()] = append(samples[frame.DownLinkType()], line)
-				existingSamples[line] = true
+			if _, exist := existingSamples[frame.RawString()]; !exist {
+				samples[frame.DownLinkType()] = append(samples[frame.DownLinkType()], frame.RawString())
+				existingSamples[frame.RawString()] = true
 			}
 		}
 	}
@@ -97,55 +127,69 @@ func gatherSamples(filePath string) {
 	for k, s := range samples {
 		println(k, ":", "['"+strings.Join(s, "', '")+"'],")
 	}
+	return nil
 }
 
-func showTypes(filePath string) {
-	f, err := getFileReader(filePath)
+func showTypes(c *cli.Context) error {
+	incomingChan, err := incoming(c)
 	if nil != err {
-		println(err)
-		return
+		return err
 	}
-	println("Processing file...")
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
+	log.Info().Msg("Processing...")
 
-		frame, err := mode_s.DecodeString(line, time.Now())
-		if nil != err {
-			//println("Error! ", line, err.Error())
+	for iframe := range incomingChan {
+		frame := modeSFrame(iframe)
+		if nil == frame {
 			continue
 		}
+
 		switch frame.DownLinkType() {
-		case 17:
-			fmt.Printf("DF%02d\tMT%02d\tST%02d\t%s\t%s\n", frame.DownLinkType(), frame.MessageType(), frame.MessageSubType(), frame.IcaoStr(), line)
+		case 0, 4, 5, 11:
+			fmt.Printf("DF%02d\t    \t    \t%s\t%s\n", frame.DownLinkType(), frame.IcaoStr(), frame.RawString())
+		case 17, 18:
+			fmt.Printf("DF%02d\tMT%02d\tST%02d\t%s\t%s\n", frame.DownLinkType(), frame.MessageType(), frame.MessageSubType(), frame.IcaoStr(), frame.RawString())
 		case 20, 21:
-			fmt.Printf("DF%02d\tBDS%s\tST%02d\t%s\t%s\n", frame.DownLinkType(), frame.BdsMessageType(), frame.MessageSubType(), frame.IcaoStr(), line)
+			fmt.Printf("DF%02d\tBDS%s\tST%02d\t%s\t%s\n", frame.DownLinkType(), frame.BdsMessageType(), frame.MessageSubType(), frame.IcaoStr(), frame.RawString())
 		default:
-			fmt.Printf("DF%02d\tMT%02d\tST%02d\t%s\t%s\n", frame.DownLinkType(), frame.MessageType(), frame.MessageSubType(), frame.IcaoStr(), line)
+			fmt.Printf("DF%02d\tMT%02d\tST%02d\t%s\t%s\n", frame.DownLinkType(), frame.MessageType(), frame.MessageSubType(), frame.IcaoStr(), frame.RawString())
 
 		}
-
 	}
-
+	return nil
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		println("first arg must be file of stored AVR packets")
-		return
-	}
-	var cmd string
-	if 3 <= len(os.Args) {
-		cmd = os.Args[2]
+	app := cli.NewApp()
+	app.Version = "1.0.0"
+	app.Name = "DF Example Finder"
+	app.Usage = "Find examples of payloads in a file"
+
+	setup.IncludeSourceFlags(app)
+	logging.IncludeVerbosityFlags(app)
+
+	app.Commands = []*cli.Command{
+		{
+			Name:   "types",
+			Usage:  "Shows message info for everything in the file",
+			Action: showTypes,
+		},
+		{
+			Name:      "gather-samples",
+			Usage:     "Gather Samples and put them in a JSON array ready for use in website_decode",
+			Action:    gatherSamples,
+			ArgsUsage: "[app.log - A file name to output to or stdout if not specified]",
+		},
 	}
 
-	switch cmd {
-	case "type":
-		showTypes(os.Args[1])
-	case "gather":
-		gatherSamples(os.Args[1])
-	default:
-		println("3rd argument must be either type or gather")
+	app.Before = func(c *cli.Context) error {
+		logging.SetLoggingLevel(c)
+		logging.ConfigureForCli()
+
+		return nil
 	}
 
+	if err := app.Run(os.Args); nil != err {
+		log.Error().Err(err).Msg("Finishing with an error")
+		os.Exit(1)
+	}
 }

--- a/lib/producer/beast.go
+++ b/lib/producer/beast.go
@@ -3,7 +3,6 @@ package producer
 import (
 	"bufio"
 	"bytes"
-	"plane.watch/lib/tracker"
 	"plane.watch/lib/tracker/beast"
 	"time"
 )
@@ -12,8 +11,6 @@ func (p *producer) beastScanner(scan *bufio.Scanner) error {
 	lastTimeStamp := time.Duration(0)
 	for scan.Scan() {
 		msg := scan.Bytes()
-		p.addFrame(beast.NewFrame(msg, false), &p.FrameSource)
-
 		frame := beast.NewFrame(msg, false)
 		if nil == frame {
 			continue
@@ -25,8 +22,8 @@ func (p *producer) beastScanner(scan *bufio.Scanner) error {
 			}
 			lastTimeStamp = currentTs
 		}
+		p.addFrame(frame, &p.FrameSource)
 
-		p.AddEvent(tracker.NewFrameEvent(frame, &p.FrameSource))
 		if nil != p.stats.beast {
 			p.stats.beast.Inc()
 		}

--- a/lib/tracker/mode_s/describe.go
+++ b/lib/tracker/mode_s/describe.go
@@ -413,7 +413,9 @@ var frameFeatures = map[byte][]featureBreakdown{
 	},
 	18: {
 		{name: "DF", start: 0, end: 5},
-		{name: "??", start: 5, end: 88},
+		{name: "CA", start: 5, end: 8},
+		{name: "AA", start: 8, end: 32},
+		{name: "ME", start: 32, end: 88, subFields: asdbFeatures},
 		{name: "CRC", start: 88, end: 112},
 	},
 	19: {

--- a/lib/tracker/mode_s/frame.go
+++ b/lib/tracker/mode_s/frame.go
@@ -593,6 +593,12 @@ func (f *Frame) Raw() []byte {
 	}
 	return []byte(f.raw)
 }
+func (f *Frame) RawString() string {
+	if nil == f {
+		return ""
+	}
+	return f.raw
+}
 
 func (f *Frame) IcaoStr() string {
 	if nil == f {


### PR DESCRIPTION
This is a small utility to scan an input and print out either some easily grep'able type info (DF17 MT31 etc) or to find a sample of frames from `website_decode`.

In this PR I have:

* Upgraded DF Example Finder to use newer code paths that give it a whole bunch more flexibility

* Found an issue with beast processing, we are now only allocating a new frame once per beast message (not 3) and only sending it for processing once (not twice)

* Added some more (light) debug messages

* Added a test to make sure we only get one beast frame per message :D