### PR TITLE
Experiment - Update Forgetful Sync Map to optionally allow outside code to determine if an item is old

### DIFF
--- a/cmd/pw_router/main.go
+++ b/cmd/pw_router/main.go
@@ -2,19 +2,17 @@ package main
 
 import (
 	"context"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
+	"os"
+	"os/signal"
 	"plane.watch/lib/dedupe/forgetfulmap"
 	"plane.watch/lib/monitoring"
+	"sync"
+	"syscall"
 
 	"plane.watch/lib/logging"
 )
@@ -194,14 +192,17 @@ func run(c *cli.Context) error {
 	var err error
 	// connect to rabbitmq, create ourselves 2 queues
 	r := pwRouter{
-		syncSamples: forgetfulmap.NewForgetfulSyncMap(time.Duration(c.Int("update-age-sweep-interval"))*time.Second, time.Duration(c.Int("update-age"))*time.Second),
+		syncSamples: forgetfulmap.NewForgetfulSyncMap(
+			forgetfulmap.WithSweepIntervalSeconds(c.Int("update-age-sweep-interval")),
+			forgetfulmap.WithOldAgeAfterSeconds(c.Int("update-age")),
+			forgetfulmap.WithPreEvictionAction(func(key, value any) {
+				cacheEvictions.Inc()
+				cacheEntries.Dec()
+				log.Debug().Msgf("Evicting cache entry Icao: %s", key)
+			}),
+		),
 	}
 
-	r.syncSamples.SetEvictionAction(func(key interface{}, value interface{}) {
-		cacheEvictions.Inc()
-		cacheEntries.Dec()
-		log.Debug().Msgf("Evicting cache entry Icao: %s", key)
-	})
 	defer r.syncSamples.Stop()
 
 	r.incomingMessages = make(chan []byte, 300)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module plane.watch
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bwmarrin/discordgo v0.23.3-0.20211228023845-29269347e820

--- a/lib/dedupe/forgetfulmap/map.go
+++ b/lib/dedupe/forgetfulmap/map.go
@@ -6,59 +6,107 @@ import (
 )
 
 type (
+	ForgettableFunc func(key, value any, added time.Time) bool
+	EvictionFunc    func(key, value any)
+
 	ForgetfulSyncMap struct {
 		lookup        *sync.Map
+		len           int
 		sweeper       *time.Timer
 		sweepInterval time.Duration
 		oldAfter      time.Duration
-		evictionFunc  func(key interface{}, value interface{})
-	}
-
-	// ForgettableItem allows us to determine if something can be forgotten
-	ForgettableItem interface {
-		CanBeForgotten(oldAfter time.Duration) bool
+		evictionFunc  EvictionFunc
+		forgettable   ForgettableFunc
 	}
 
 	// a generic wrapper for things that can be lost
 	marble struct {
-		age   time.Time
-		value interface{}
+		added time.Time
+		value any
 	}
+
+	Option func(*ForgetfulSyncMap)
 )
 
-func NewForgetfulSyncMap(interval time.Duration, oldTime time.Duration) *ForgetfulSyncMap {
-	f := ForgetfulSyncMap{
+func NewForgetfulSyncMap(opts ...Option) *ForgetfulSyncMap {
+	f := &ForgetfulSyncMap{
 		lookup:        &sync.Map{},
-		sweepInterval: interval,
-		oldAfter:      oldTime,
+		len:           0,
+		sweepInterval: 10 * time.Second,
+		oldAfter:      60 * time.Second,
 	}
-	f.sweeper = time.AfterFunc(f.oldAfter, func() {
+	for _, opt := range opts {
+		opt(f)
+	}
+	f.sweeper = time.AfterFunc(f.sweepInterval, func() {
 		f.sweep()
 		f.sweeper.Reset(f.sweepInterval)
 	})
+	if nil == f.forgettable {
+		f.forgettable = OldAfterForgettableAction(f.oldAfter)
+	}
 
-	return &f
+	return f
 }
 
-func (m *marble) CanBeForgotten(oldAfter time.Duration) bool {
-	// calc the oldest this item can be
-	oldest := time.Now().Add(-oldAfter)
-	return !m.age.After(oldest)
+// WithSweepIntervalSeconds is a helper function that Sets the Sweep Interval, so you don't have to cast as much
+func WithSweepIntervalSeconds(numSeconds int) Option {
+	return WithSweepInterval(time.Duration(numSeconds) * time.Second)
 }
 
-func (f *ForgetfulSyncMap) SetEvictionAction(evictFunc func(key interface{}, value interface{})) {
-	f.evictionFunc = evictFunc
+// WithOldAgeAfterSeconds is a helper function that Sets the Old Age, so you don't have to cast as much
+func WithOldAgeAfterSeconds(numSeconds int) Option {
+	return WithOldAgeAfter(time.Duration(numSeconds) * time.Second)
 }
 
+// WithSweepInterval sets how often we look to expire items
+func WithSweepInterval(d time.Duration) Option {
+	return func(f *ForgetfulSyncMap) {
+		f.sweepInterval = d
+	}
+}
+
+// WithOldAgeAfter sets the time at which our default forgetting action declares an items should be forgotten
+func WithOldAgeAfter(d time.Duration) Option {
+	return func(f *ForgetfulSyncMap) {
+		f.oldAfter = d
+	}
+}
+
+// OldAfterForgettableAction is the default action to determine if an item in our sync.Map should be forgotten.
+// it is simply "removable after being in the sync.Map for the given time.Duration"
+func OldAfterForgettableAction(oldAfter time.Duration) ForgettableFunc {
+	return func(key any, value any, added time.Time) bool {
+		oldest := time.Now().Add(-oldAfter)
+		return added.Before(oldest)
+	}
+}
+
+// WithPreEvictionAction Sets the function that is called just before we evict the item
+func WithPreEvictionAction(evictFunc EvictionFunc) Option {
+	return func(f *ForgetfulSyncMap) {
+		f.evictionFunc = evictFunc
+	}
+}
+
+// WithForgettableAction sets the action that determines if an item should be forgotten
+// if your ForgettableFunc returns true, the eviction action is called and then the item is removed
+func WithForgettableAction(forgettable ForgettableFunc) Option {
+	return func(f *ForgetfulSyncMap) {
+		f.forgettable = forgettable
+	}
+}
+
+// sweep periodically goes through the underlying sync.Map and removes things that should be forgotten
 func (f *ForgetfulSyncMap) sweep() {
 	f.lookup.Range(func(key, value interface{}) bool {
-		t, ok := value.(ForgettableItem)
+		m, ok := value.(*marble)
 		if !ok {
-			// cannot forget something which cannot be forgotten
+			// not entirely sure how a non marble object got in, but whatever
 			return true
 		}
 
-		if t.CanBeForgotten(f.oldAfter) {
+		if f.forgettable(key, value, m.added) {
 			if f.evictionFunc != nil {
 				f.evictionFunc(key, value)
 			}
@@ -69,6 +117,8 @@ func (f *ForgetfulSyncMap) sweep() {
 	})
 }
 
+// HasKey determines if we can Recall an item
+// You should use the Load method if you need the return value
 func (f *ForgetfulSyncMap) HasKey(key interface{}) bool {
 	if _, ok := f.lookup.Load(key); ok {
 		return true
@@ -76,6 +126,7 @@ func (f *ForgetfulSyncMap) HasKey(key interface{}) bool {
 	return false
 }
 
+// AddKey adds an item to the list without a value
 func (f *ForgetfulSyncMap) AddKey(key interface{}) {
 	// avoid storing empty things
 	if nil == key {
@@ -91,41 +142,38 @@ func (f *ForgetfulSyncMap) AddKey(key interface{}) {
 			return
 		}
 	}
-	f.Store(key, &marble{
-		age: time.Now(),
-	})
+	f.Store(key, nil)
 }
 
-func (f *ForgetfulSyncMap) Load(key interface{}) (interface{}, bool) {
+// Load attempts to recall an item from the list
+func (f *ForgetfulSyncMap) Load(key any) (any, bool) {
 	retVal, retBool := f.lookup.Load(key)
 
 	if retBool {
-		t, tok := retVal.(*marble)
-		if tok {
+		if t, tok := retVal.(*marble); tok {
 			return t.value, retBool
 		} else {
-			return t, retBool
+			return nil, false
 		}
 	} else {
 		return retVal, retBool
 	}
 }
 
+// Store remembers an item
 func (f *ForgetfulSyncMap) Store(key, value interface{}) {
-	if _, ok := value.(ForgettableItem); ok {
-		f.lookup.Store(key, value)
-	} else {
-		f.lookup.Store(key, &marble{
-			age:   time.Now(),
-			value: value,
-		})
-	}
+	f.lookup.Store(key, &marble{
+		added: time.Now(),
+		value: value,
+	})
 }
 
+// Delete Removes an item from the list
 func (f *ForgetfulSyncMap) Delete(key interface{}) {
 	f.lookup.Delete(key)
 }
 
+// Len returns a count of the number of items in the list
 func (f *ForgetfulSyncMap) Len() (entries int32) {
 	f.lookup.Range(func(key interface{}, value interface{}) bool {
 		entries++
@@ -135,6 +183,7 @@ func (f *ForgetfulSyncMap) Len() (entries int32) {
 	return entries
 }
 
+// Range Iterates over the underlying sync.Map and calls the user function once per item
 func (f *ForgetfulSyncMap) Range(rangeFunc func(key, value interface{}) bool) {
 	f.lookup.Range(func(key, value interface{}) bool {
 		if m, ok := value.(*marble); ok {
@@ -146,6 +195,7 @@ func (f *ForgetfulSyncMap) Range(rangeFunc func(key, value interface{}) bool) {
 	})
 }
 
+// Stop tells us to stop forgetting.
 func (f *ForgetfulSyncMap) Stop() {
 	f.sweeper.Stop()
 }

--- a/lib/dedupe/main.go
+++ b/lib/dedupe/main.go
@@ -2,8 +2,6 @@ package dedupe
 
 import (
 	"fmt"
-	"time"
-
 	"plane.watch/lib/dedupe/forgetfulmap"
 	"plane.watch/lib/tracker"
 	"plane.watch/lib/tracker/beast"
@@ -26,7 +24,7 @@ type (
 
 func NewFilter() *Filter {
 	return &Filter{
-		list:   forgetfulmap.NewForgetfulSyncMap(10*time.Second, 60*time.Second),
+		list:   forgetfulmap.NewForgetfulSyncMap(),
 		events: make(chan tracker.Event),
 	}
 }

--- a/lib/sink/sink.go
+++ b/lib/sink/sink.go
@@ -14,8 +14,6 @@ import (
 	"plane.watch/lib/tracker/beast"
 	"plane.watch/lib/tracker/mode_s"
 	"plane.watch/lib/tracker/sbs1"
-
-	"time"
 )
 
 type (
@@ -47,7 +45,7 @@ func stripAnsi(str string) string {
 
 func NewSink(conf *Config, dest Destination) tracker.Sink {
 	s := Sink{
-		fsm:    forgetfulmap.NewForgetfulSyncMap(10*time.Second, 60*time.Second),
+		fsm:    forgetfulmap.NewForgetfulSyncMap(),
 		config: conf,
 		dest:   dest,
 		events: make(chan tracker.Event),


### PR DESCRIPTION
This branch is for exploring different ideas on how to configure ForgetfulSyncMap to allow customisable expiry times.

We first explored having each item be able to determine if it was "old", but that turned out to be a little clunky

I have now gone and made it possible to configure the ForgetfulSyncMap with an Option for a method that does the "is this thing old" calculation which works quite nicely

To see how it worked with the pw_ws_broker I needed to drag `main` into my branch, so there is also all of main going into sirsquidness's branch too - sorry for the noise