### PR TITLE
Perf Testing and Improvement - Beast Ingest Allocations

### DIFF
--- a/lib/producer/avr.go
+++ b/lib/producer/avr.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func (p *producer) avrScanner(scan *bufio.Scanner) error {
+func (p *Producer) avrScanner(scan *bufio.Scanner) error {
 	for scan.Scan() {
 		line := scan.Text()
 		p.addFrame(mode_s.NewFrame(line, time.Now()), &p.FrameSource)

--- a/lib/producer/beast.go
+++ b/lib/producer/beast.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func (p *producer) beastScanner(scan *bufio.Scanner) error {
+func (p *Producer) beastScanner(scan *bufio.Scanner) error {
 	lastTimeStamp := time.Duration(0)
 	for scan.Scan() {
 		msg := scan.Bytes()
@@ -32,75 +32,80 @@ func (p *producer) beastScanner(scan *bufio.Scanner) error {
 }
 
 // ScanBeast is a splitter for BEAST format messages
-func ScanBeast(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if atEOF && len(data) == 0 {
-		return 0, nil, nil
-	}
+func ScanBeast() func(data []byte, atEOF bool) (int, []byte, error) {
+	var token [50]byte
 
-	// skip until we get our first 0x1A (message start)
-	i := bytes.IndexByte(data, 0x1A)
-	if -1 == i || len(data) < i+11 {
-		// we do not even have the smallest message, let's get some more data
-		return 0, nil, nil
-	}
-	// byte 2 is our message type, so it tells us how long this message is
-	msgLen := 0
-	switch data[i+1] {
-	case 0x31:
-		// mode-ac 11 bytes (2+8)
-		// 1(esc), 1(type), 6(mlat), 1(signal), 2(mode-ac)
-		msgLen = 11
-	case 0x32:
-		// mode-s short 16 bytes
-		// 1(esc), 1(type), 6(mlat), 1(signal), 7(mode-s short)
-		msgLen = 16
-	case 0x33:
-		// mode-s long 23 bytes
-		// 1(esc), 1(type), 6(mlat), 1(signal), 14(mode-s extended squitter)
-		msgLen = 23
-	case 0x34:
-		// Config Settings and Stats
-		// 1(esc), 1(type), 6(mlat), 1(unused), (1)DIP Config, (1)timestamp error ticks
-		msgLen = 11
-	default:
-		// unknown? assume we got an out of sequence and skip
-		return i + 1, nil, nil
-	}
-	bufLen := len(data)
-	//println("type", data[i+1], "input len", bufLen, "msg len",msgLen)
-	if bufLen >= i+msgLen {
-		// we have enough in our buffer
-		// account for double escapes
-		advance = msgLen
-		max := msgLen * 2
-		token = make([]byte, msgLen)
-		dataIndex := i // start at the <esc>/0x1a
-		tokenIndex := 0
-		token[tokenIndex] = data[dataIndex]
-		for dataIndex < i+advance-1 && dataIndex < i+max {
-			dataIndex++ // first inc skips past the first 0x1a
-			tokenIndex++
-			// can we get to the next byte?
-			if dataIndex+1 > bufLen {
-				// run out of buffer, want more
-				return 0, nil, nil
-			}
-
-			token[tokenIndex] = data[dataIndex]
-			if data[dataIndex] != 0x1A { // messages start with 0x1A
-				continue
-			}
-			if dataIndex+2 > bufLen {
-				// run out of buffer, want more
-				return 0, nil, nil
-			}
-			if data[dataIndex+1] == 0x1A { // skip over the second <esc>
-				advance++
-				dataIndex++
-			}
+	return func(data []byte, atEOF bool) (int, []byte, error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
 		}
-		return advance, token, nil
+
+		// skip until we get our first 0x1A (message start)
+		i := bytes.IndexByte(data, 0x1A)
+		if -1 == i || len(data) < i+11 {
+			// we do not even have the smallest message, let's get some more data
+			return 0, nil, nil
+		}
+		// byte 2 is our message type, so it tells us how long this message is
+		msgLen := 0
+		switch data[i+1] {
+		case 0x31:
+			// mode-ac 11 bytes (2+8)
+			// 1(esc), 1(type), 6(mlat), 1(signal), 2(mode-ac)
+			msgLen = 11
+		case 0x32:
+			// mode-s short 16 bytes
+			// 1(esc), 1(type), 6(mlat), 1(signal), 7(mode-s short)
+			msgLen = 16
+		case 0x33:
+			// mode-s long 23 bytes
+			// 1(esc), 1(type), 6(mlat), 1(signal), 14(mode-s extended squitter)
+			msgLen = 23
+		case 0x34:
+			// Config Settings and Stats
+			// 1(esc), 1(type), 6(mlat), 1(unused), (1)DIP Config, (1)timestamp error ticks
+			msgLen = 11
+		default:
+			// unknown? assume we got an out of sequence and skip
+			return i + 1, nil, nil
+		}
+		bufLen := len(data)
+		//println("type", data[i+1], "input len", bufLen, "msg len",msgLen)
+		if bufLen >= i+msgLen {
+			// we have enough in our buffer
+			// account for double escapes
+			advance := msgLen
+			max := msgLen << 1
+			//token = make([]byte, msgLen)
+
+			dataIndex := i // start at the <esc>/0x1a
+			tokenIndex := 0
+			token[tokenIndex] = data[dataIndex]
+			for dataIndex < i+advance-1 && dataIndex < i+max {
+				dataIndex++ // first inc skips past the first 0x1a
+				tokenIndex++
+				// can we get to the next byte?
+				if dataIndex+1 > bufLen {
+					// run out of buffer, want more
+					return 0, nil, nil
+				}
+
+				token[tokenIndex] = data[dataIndex]
+				if data[dataIndex] != 0x1A { // messages start with 0x1A
+					continue
+				}
+				if dataIndex+2 > bufLen {
+					// run out of buffer, want more
+					return 0, nil, nil
+				}
+				if data[dataIndex+1] == 0x1A { // skip over the second <esc>
+					advance++
+					dataIndex++
+				}
+			}
+			return advance, token[0:msgLen], nil
+		}
+		// we want more data!
+		return 0, nil, nil
 	}
-	// we want more data!
-	return 0, nil, nil
 }

--- a/lib/producer/beast_test.go
+++ b/lib/producer/beast_test.go
@@ -3,6 +3,7 @@ package producer
 import (
 	"bufio"
 	"bytes"
+	"os"
 	"plane.watch/lib/tracker"
 	"reflect"
 	"sync"
@@ -116,7 +117,8 @@ func TestScanBeast(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAdvance, gotToken, err := ScanBeast(tt.args.data, tt.args.atEOF)
+			scanner := ScanBeast()
+			gotAdvance, gotToken, err := scanner(tt.args.data, tt.args.atEOF)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ScanBeast() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -166,5 +168,20 @@ func Test_producer_beastScanner(t *testing.T) {
 	}
 	if unexpectedCounter != 0 {
 		t.Errorf("Got Unexpected Messaged. got %d, expected 1", expectedCounter)
+	}
+}
+
+func BenchmarkScanBeast(b *testing.B) {
+	f, err := os.Open("testdata/beast.sample")
+	if nil != err {
+		b.Fatal(err)
+	}
+
+	for n := 0; n < b.N; n++ {
+		f.Seek(0, 0)
+		scanner := bufio.NewScanner(f)
+		scanner.Split(ScanBeast())
+		for scanner.Scan() {
+		}
 	}
 }

--- a/lib/producer/sbs1.go
+++ b/lib/producer/sbs1.go
@@ -5,7 +5,7 @@ import (
 	"plane.watch/lib/tracker/sbs1"
 )
 
-func (p *producer) sbsScanner(scan *bufio.Scanner) error {
+func (p *Producer) sbsScanner(scan *bufio.Scanner) error {
 	for scan.Scan() {
 		line := scan.Text()
 		p.addFrame(sbs1.NewFrame(scan.Text()), &p.FrameSource)


### PR DESCRIPTION
Change the beast scanner to not do a memory allocation for every message it processes, but rather use a common scratch []byte and return out of it

Testing with

  go test -bench . -count 5 -benchmem

We go from an original

```
goos: linux
goarch: amd64
pkg: plane.watch/lib/producer
cpu: AMD Ryzen 7 3800X 8-Core Processor
BenchmarkScanBeast-16                 25          42657336 ns/op         5332599 B/op     272665 allocs/op
BenchmarkScanBeast-16                 27          43686231 ns/op         5332491 B/op     272665 allocs/op
BenchmarkScanBeast-16                 31          44063729 ns/op         5332415 B/op     272665 allocs/op
BenchmarkScanBeast-16                 27          41658114 ns/op         5332416 B/op     272665 allocs/op
BenchmarkScanBeast-16                 31          40061668 ns/op         5332418 B/op     272665 allocs/op
PASS
ok      plane.watch/lib/producer        6.489s
```
down to
```
goos: linux
goarch: amd64
pkg: plane.watch/lib/producer
cpu: AMD Ryzen 7 3800X 8-Core Processor
BenchmarkScanBeast-16                 74          16236748 ns/op            4177 B/op          3 allocs/op
BenchmarkScanBeast-16                 75          16548997 ns/op            4177 B/op          3 allocs/op
BenchmarkScanBeast-16                 69          16108247 ns/op            4177 B/op          3 allocs/op
BenchmarkScanBeast-16                 68          15988906 ns/op            4177 B/op          3 allocs/op
BenchmarkScanBeast-16                 69          16162476 ns/op            4177 B/op          3 allocs/op
PASS
ok      plane.watch/lib/producer        7.363s
```