### PR TITLE
Clickhouse History Path Fixing

### DIFF
--- a/cmd/pw_router/main.go
+++ b/cmd/pw_router/main.go
@@ -251,7 +251,7 @@ func run(c *cli.Context) error {
 		cli.ShowAppHelpAndExit(c, 1)
 	}
 
-	var ds *dataStream
+	var ds *DataStream
 	if chUrl := c.String("clickhouse"); "" != chUrl {
 		chs, err := clickhouse.New(chUrl)
 		if nil != err {

--- a/cmd/pw_router/worker.go
+++ b/cmd/pw_router/worker.go
@@ -14,7 +14,7 @@ type (
 		destRoutingKey string
 		spreadUpdates  bool
 
-		ds *dataStream
+		ds *DataStream
 	}
 )
 


### PR DESCRIPTION
Use a string to represent the date for inserting into clickhouse (since DateTime64 was not handling int64 nanoseconds nicely)

some more error handling and fixes