### PR TITLE
MOAR PLANES

### DIFF
--- a/lib/tracker/tracker.go
+++ b/lib/tracker/tracker.go
@@ -421,6 +421,12 @@ func (p *Plane) HandleModeSFrame(frame *mode_s.Frame, refLat, refLon *float64) {
 		}
 	}
 
+	if "" == p.location.gridTileLocation && nil != refLat && nil != refLon {
+		// do not have a grid tile for this plane, let's assume it is in same tile as the receiver
+		p.location.gridTileLocation = tile_grid.LookupTile(*refLat, *refLon)
+		hasChanged = p.location.gridTileLocation != "" || hasChanged
+	}
+
 	if hasChanged {
 		p.tracker.sink.OnEvent(NewPlaneLocationEvent(p))
 	}


### PR DESCRIPTION
if a plane does not (yet) have a tile grid, and we have the receivers lat/lon - assign the plane the same tile grid as the receiver

Motivation: Not every plane sends it's location. we can at least display them (and their height) on the main website