### PR TITLE
ingest-tap

### DIFF
--- a/cmd/ingest_tap/main.go
+++ b/cmd/ingest_tap/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v2"
+	"os"
+	"os/signal"
+	"plane.watch/lib/logging"
+	"plane.watch/lib/nats_io"
+	"plane.watch/lib/randstr"
+	"plane.watch/lib/tracker/beast"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	natsUrl = "nats"
+	apiKey  = "api-key"
+	icao    = "icao"
+	logFile = "file"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "pw_ingest tap"
+	app.Description = "Ask all of the pw_ingest instances on the nats bus to feed matching data to this terminal.\n" +
+		"Matching beast/avr/sbs1 messages will be forwarded to you"
+
+	app.Commands = cli.Commands{
+		{
+			Name:        "log",
+			Description: "Logs matching data to a file",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  icao,
+					Usage: "if specified, only frames from the plane with the specified ICAO will be sent",
+				},
+				&cli.StringFlag{
+					Name:  apiKey,
+					Usage: "the plane.watch api UUID for the given feeder you want to investigate",
+				},
+				&cli.StringFlag{
+					Name:  logFile,
+					Value: "captured-frames",
+					Usage: "[.beast|.avr|.sbs1] will be appended to file",
+				},
+			},
+			Action: logMatching,
+		},
+	}
+
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  natsUrl,
+			Usage: "nats url",
+			Value: "nats://localhost:4222/",
+		},
+	}
+	logging.IncludeVerbosityFlags(app)
+	app.Before = func(c *cli.Context) error {
+		logging.SetLoggingLevel(c)
+
+		return nil
+	}
+
+	if err := app.Run(os.Args); nil != err {
+		log.Error().Err(err).Send()
+	}
+}
+
+func logMatching(c *cli.Context) error {
+	logging.ConfigureForCli()
+	fileHandles := make(map[string]*os.File)
+	exts := []string{"beast", "avr", "sbs1"}
+	for _, ext := range exts {
+		fileName := c.String(logFile) + "." + ext
+		fh, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0666)
+		if nil != err {
+			log.Error().Err(err).Str("filename", fileName).Send()
+			return err
+		}
+		fileHandles[ext] = fh
+	}
+
+	natsSvr, err := nats_io.NewServer(
+		nats_io.WithConnections(true, true),
+		nats_io.WithServer(c.String(natsUrl), "ingest-tap"),
+	)
+	if nil != err {
+		return err
+	}
+
+	tapSubject := "ingest-tap-" + randstr.RandString(20)
+	ch, err := natsSvr.Subscribe(tapSubject)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go handleStream(ch, fileHandles, &wg)
+
+	headers := map[string]string{
+		"action":  "add",
+		"api-key": c.String(apiKey),
+		"icao":    c.String(icao),
+		"subject": tapSubject,
+	}
+
+	response, errRq := natsSvr.Request("v1.pw-ingest.tap", []byte{}, headers, time.Second)
+	if nil != errRq {
+		log.Error().Err(err).Msg("Failed to request tap")
+		return err
+	}
+	log.Debug().Str("response", string(response)).Msg("request response")
+
+	chSignal := make(chan os.Signal, 1)
+	signal.Notify(chSignal, syscall.SIGINT, syscall.SIGTERM)
+	<-chSignal // wait for our cancel signal
+	log.Info().Msg("Shutting down")
+
+	// ask to step sending
+	headers["action"] = "remove"
+	response, errRq = natsSvr.Request("v1.pw-ingest.tap", []byte{}, headers, time.Second)
+	if nil != errRq {
+		log.Error().Err(err).Msg("Failed to stop tap")
+		return err
+	}
+	log.Debug().Str("response", string(response)).Msg("request response")
+
+	close(ch)
+	wg.Wait()
+
+	for ext, f := range fileHandles {
+		err = f.Close()
+		if err != nil {
+			log.Error().Err(err).Str("ext", ext).Msg("Failed to close file")
+		}
+	}
+
+	log.Info().Msg("Shut down complete")
+	return nil
+}
+
+func handleStream(ch chan *nats.Msg, fileHandles map[string]*os.File, wg *sync.WaitGroup) {
+	for msg := range ch {
+		switch msg.Header.Get("type") {
+		case "beast":
+			b, err := beast.NewFrame(msg.Data, false)
+			log.Info().
+				Str("ICAO", b.IcaoStr()).
+				Str("AVR", b.RawString()).
+				Str("tag", msg.Header.Get("tag")).
+				Send()
+
+			// TODO: Replace timestamp with our own
+			_, err = fileHandles["beast"].Write(msg.Data)
+			if err != nil {
+				log.Error().Err(err).Send()
+			}
+		case "avr":
+			_, err := fileHandles["avr"].Write(append(msg.Data, 10))
+			if err != nil {
+				log.Error().Err(err).Send()
+			}
+		case "sbs1":
+			_, err := fileHandles["sbs1"].Write(append(msg.Data, 10))
+			if err != nil {
+				log.Error().Err(err).Send()
+			}
+
+		}
+	}
+	wg.Done()
+}

--- a/cmd/plane.path/avr.go
+++ b/cmd/plane.path/avr.go
@@ -42,12 +42,18 @@ var lastSeenMap sync.Map
 
 // Handle ensures we have enough time between messages for a plane to have travelled the distance it says it did
 // this is because we do not have the timestamp for when it was collected when processing AVR frames
-func (fm *timeFiddler) Handle(f tracker.Frame) tracker.Frame {
-	switch f.(type) {
+func (fm *timeFiddler) Handle(fe *tracker.FrameEvent) tracker.Frame {
+	if nil == fe {
+		return nil
+	}
+	f := fe.Frame()
+	if nil == f {
+		return nil
+	}
+	switch frame := f.(type) {
 	case *mode_s.Frame:
 		lastSeen, _ := lastSeenMap.LoadOrStore(f.Icao(), time.Now().Add(-24*time.Hour))
 		t := lastSeen.(time.Time)
-		frame := f.(*mode_s.Frame)
 		if 17 == frame.DownLinkType() {
 			switch frame.MessageTypeString() {
 			case mode_s.DF17FrameSurfacePos, mode_s.DF17FrameAirPositionGnss, mode_s.DF17FrameAirPositionBarometric:

--- a/cmd/pw_ingest/main.go
+++ b/cmd/pw_ingest/main.go
@@ -9,8 +9,11 @@ import (
 	"plane.watch/lib/dedupe"
 	"plane.watch/lib/example_finder"
 	"plane.watch/lib/logging"
+	"plane.watch/lib/middleware"
 	"plane.watch/lib/monitoring"
+	"plane.watch/lib/nats_io"
 	"plane.watch/lib/setup"
+	"plane.watch/lib/sink"
 	"plane.watch/lib/tracker"
 )
 
@@ -111,11 +114,17 @@ func commonSetup(c *cli.Context) (*tracker.Tracker, error) {
 		trk.AddMiddleware(dedupe.NewFilter(dedupe.WithDedupeCounter(prometheusOutputFrameDedupe)))
 		//trk.AddMiddleware(dedupe.NewFilterBTree(dedupe.WithDedupeCounterBTree(prometheusOutputFrameDedupe), dedupe.WithBtreeDegree(16)))
 	}
-	sink, err := setup.HandleSinkFlag(c, "pw_ingest")
+	sinkDest, err := setup.HandleSinkFlag(c, "pw_ingest")
 	if nil != err {
 		return nil, err
 	}
-	trk.SetSink(sink)
+	trk.SetSink(sinkDest)
+
+	if sinkType, ok := sinkDest.(*sink.Sink); ok {
+		if ns, ok := sinkType.Server().(*nats_io.Server); ok {
+			trk.AddMiddleware(middleware.NewIngestTap(ns))
+		}
+	}
 
 	producers, err := setup.HandleSourceFlags(c)
 	if nil != err {

--- a/cmd/pw_ws_broker/web.go
+++ b/cmd/pw_ws_broker/web.go
@@ -266,7 +266,8 @@ func (cl *ClientList) performSearch(query string) ws_protocol.SearchResult {
 
 	// Airport Lookup, if we have a nats connection
 	if nil != cl.broker.natsRpc {
-		resp, err := cl.broker.natsRpc.Request(export.NatsApiSearchAirportV1, []byte(query), time.Second)
+		headers := map[string]string{}
+		resp, err := cl.broker.natsRpc.Request(export.NatsApiSearchAirportV1, []byte(query), headers, time.Second)
 		if nil != err {
 			log.Error().Err(err).Msg("Failed to search for airport")
 		} else {

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -122,7 +122,11 @@ func (fp *frameProcessor) String() string {
 func (fp *frameProcessor) Listen() chan tracker.Event {
 	return fp.events
 }
-func (fp *frameProcessor) Handle(frame tracker.Frame) tracker.Frame {
+func (fp *frameProcessor) Handle(fe *tracker.FrameEvent) tracker.Frame {
+	if nil == fe {
+		return nil
+	}
+	frame := fe.Frame()
 	if nil == frame {
 		return nil
 	}

--- a/lib/dedupe/dedupe.go
+++ b/lib/dedupe/dedupe.go
@@ -43,7 +43,11 @@ func NewFilter(opts ...Option) *Filter {
 	return &f
 }
 
-func (f *Filter) Handle(frame tracker.Frame) tracker.Frame {
+func (f *Filter) Handle(fe *tracker.FrameEvent) tracker.Frame {
+	if nil == fe {
+		return nil
+	}
+	frame := fe.Frame()
 	if nil == frame {
 		return nil
 	}

--- a/lib/example_finder/filter.go
+++ b/lib/example_finder/filter.go
@@ -80,7 +80,11 @@ func (f *Filter) String() string {
 	return "Example Finder/Filter"
 }
 
-func (f *Filter) Handle(frame tracker.Frame) tracker.Frame {
+func (f *Filter) Handle(fe *tracker.FrameEvent) tracker.Frame {
+	if nil == fe {
+		return nil
+	}
+	frame := fe.Frame()
 	if nil == frame {
 		return nil
 	}

--- a/lib/middleware/ingest_tap.go
+++ b/lib/middleware/ingest_tap.go
@@ -1,0 +1,212 @@
+package middleware
+
+import (
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog/log"
+	"plane.watch/lib/nats_io"
+	"plane.watch/lib/randstr"
+	"plane.watch/lib/tracker"
+	"plane.watch/lib/tracker/beast"
+	"plane.watch/lib/tracker/mode_s"
+	"plane.watch/lib/tracker/sbs1"
+	"strconv"
+	"sync"
+)
+
+type (
+	IngestTap struct {
+		head, tail *condition
+		queue      chan *tracker.FrameEvent
+		queueWg    sync.WaitGroup
+		natsQueue  string
+		natsServer *nats_io.Server
+		sub        *nats.Subscription
+	}
+
+	condition struct {
+		nextItem *condition
+		prevItem *condition
+		queue    string
+		apiKey   string
+		icao     uint32
+	}
+)
+
+func NewIngestTap(natsServer *nats_io.Server) tracker.Middleware {
+	tap := &IngestTap{
+		head:       nil,
+		tail:       nil,
+		queue:      make(chan *tracker.FrameEvent, 100),
+		natsServer: natsServer,
+	}
+	for i := 0; i < 8; i++ {
+		tap.queueWg.Add(1)
+		go tap.processQueue()
+	}
+	var err error
+	tap.natsQueue = "pw-ingest-tap-" + randstr.RandString(20)
+	tap.sub, err = tap.natsServer.SubscribeReply("v1.pw-ingest.tap", tap.natsQueue, tap.requestHandler)
+	if err != nil {
+		return nil
+	}
+	log.Info().Msg("Including Ingest Tap")
+	return tap
+}
+
+func (tap *IngestTap) Close() {
+	close(tap.queue)
+	tap.queueWg.Wait()
+	err := tap.sub.Unsubscribe()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to unsubscribe from nats")
+	}
+}
+
+func (tap *IngestTap) processQueue() {
+	for frame := range tap.queue {
+		for c := tap.head; c != nil; c = c.nextItem {
+			if c.match(frame) {
+				tap.send(c.queue, frame)
+			}
+		}
+	}
+	tap.queueWg.Done()
+}
+
+func (tap *IngestTap) requestHandler(msg *nats.Msg) {
+	if nil == msg {
+		return
+	}
+	action := msg.Header.Get("action")
+	apiKey := msg.Header.Get("api-key")
+	icao := msg.Header.Get("icao") // formatted like 7C1234
+	returnSubject := msg.Header.Get("subject")
+	log.Info().
+		Str("action", action).
+		Str("apiKey", apiKey).
+		Str("icao", icao).
+		Str("returnSubject", returnSubject).
+		Msg("Network Tap Request")
+
+	var err error
+	var uIcao uint64
+
+	if "" != icao {
+		uIcao, err = strconv.ParseUint(icao, 16, 32)
+		if nil != err {
+			log.Error().Err(err).Str("icao", icao).Msg("Failed to convert ICAO string into a uint")
+		}
+	}
+
+	c := &condition{
+		queue:  returnSubject,
+		apiKey: apiKey,
+		icao:   uint32(uIcao),
+	}
+
+	switch action {
+	case "add":
+		tap.append(c)
+	case "remove":
+		tap.remove(c)
+	}
+	_ = msg.Respond([]byte("Ack"))
+}
+
+func (tap *IngestTap) String() string {
+	return "Ingest Tap"
+}
+
+func (tap *IngestTap) Handle(frame *tracker.FrameEvent) tracker.Frame {
+	if tap.head != nil {
+		tap.queue <- frame
+	}
+	return frame.Frame()
+}
+
+func (tap *IngestTap) send(subject string, fe *tracker.FrameEvent) {
+	headers := make(map[string]string)
+	headers["tag"] = fe.Source().Tag
+
+	var msg []byte
+	switch tFrame := fe.Frame().(type) {
+	case *beast.Frame:
+		headers["type"] = "beast"
+		msg = tFrame.Raw()
+	case *mode_s.Frame:
+		headers["type"] = "avr"
+		msg = tFrame.Raw()
+	case *sbs1.Frame:
+		headers["type"] = "sbs1"
+		msg = tFrame.Raw()
+	default:
+		log.Error().Msg("Unknown frame type, cannot send")
+		return
+	}
+
+	if err := tap.natsServer.PublishWithHeaders(subject, msg, headers); nil != err {
+		log.Error().Err(err).Msg("Failed to send tap data")
+	}
+}
+
+func (tap *IngestTap) append(c *condition) {
+	if nil == tap.head {
+		tap.head = c
+		tap.tail = c
+		return
+	}
+	c.prevItem = tap.tail
+	tap.tail.nextItem = c
+	tap.tail = c
+}
+
+func (tap *IngestTap) remove(c *condition) {
+	if nil == c {
+		return
+	}
+	for cond := tap.head; nil != cond; cond = cond.nextItem {
+		if cond.queue == c.queue && cond.apiKey == c.apiKey && cond.icao == c.icao {
+			// removal required
+			if tap.head == cond {
+				tap.head = cond.nextItem
+			}
+			if tap.tail == cond {
+				tap.tail = cond.prevItem
+			}
+			if nil != cond.prevItem {
+				cond.prevItem.nextItem = cond.nextItem
+			}
+			if nil != cond.nextItem {
+				cond.nextItem.prevItem = cond.prevItem
+			}
+			// and finally unlink it
+			cond.nextItem = nil
+			cond.prevItem = nil
+		}
+	}
+}
+
+func (c *condition) match(fe *tracker.FrameEvent) bool {
+	if nil == fe {
+		return false
+	}
+	isMatchApiKey := true
+	if "" != c.apiKey {
+		source := fe.Source()
+		if nil == source {
+			return false
+		}
+		isMatchApiKey = source.Tag == c.apiKey
+	}
+
+	isMatchIcao := true
+	if 0 != c.icao {
+		frame := fe.Frame()
+		if nil == frame {
+			return false
+		}
+		isMatchIcao = frame.Icao() == c.icao
+	}
+
+	return isMatchApiKey && isMatchIcao
+}

--- a/lib/middleware/ingest_tap_test.go
+++ b/lib/middleware/ingest_tap_test.go
@@ -1,0 +1,264 @@
+package middleware
+
+import (
+	"testing"
+)
+
+func TestLinkedListAddTest(t *testing.T) {
+	tap := IngestTap{}
+	if nil != tap.head {
+		t.Errorf("Zero value of IngestTap has a non nil head")
+		return
+	}
+	if nil != tap.tail {
+		t.Errorf("Zero value of IngestTap has a non nil tail")
+		return
+	}
+
+	cond1 := &condition{}
+	cond2 := &condition{}
+	cond3 := &condition{}
+
+	///////// First item
+	tap.append(cond1)
+	if cond1 != tap.head {
+		t.Errorf("Failed to set tap.head to our newly added item")
+		return
+	}
+	if cond1 != tap.tail {
+		t.Errorf("Failed to set tap.tail to our newly added item")
+		return
+	}
+
+	///////// Second item
+	tap.append(cond2)
+	if cond1 != tap.head {
+		t.Errorf("Failed to set tap.head to our newly added second item")
+		return
+	}
+	if cond2 != tap.tail {
+		t.Errorf("Failed to set tap.tail to our newly added second item")
+		return
+	}
+	if nil != cond1.prevItem {
+		t.Errorf("Somehow the tap.head has a previous item")
+		return
+	}
+
+	if cond2 != cond1.nextItem {
+		t.Errorf("Did not correctly set cond2 as cond1's next item")
+		return
+	}
+	if cond2.prevItem != cond1 {
+		t.Errorf("Did not correctly set cond2's prevItem to be cond1")
+		return
+	}
+
+	///////// Third item
+	tap.append(cond3)
+	if cond3 != tap.tail {
+		t.Errorf("Failed to set tap.tail to our newly added third item")
+		return
+	}
+	if cond3 != cond2.nextItem {
+		t.Errorf("Failed to set cond2's nextItem to our newly added third item")
+		return
+	}
+	if cond2 != cond3.prevItem {
+		t.Errorf("Failed to set cond3's prevItem to our second item")
+		return
+	}
+
+	if tap.head != cond1 || cond1.nextItem != cond2 {
+		t.Errorf("cond1 is not setup correctly after adding third item")
+	}
+}
+
+func TestLinkedListAddRemoveNone(t *testing.T) {
+	tap := IngestTap{}
+	if nil != tap.head {
+		t.Errorf("Zero value of IngestTap has a non nil head")
+		return
+	}
+	if nil != tap.tail {
+		t.Errorf("Zero value of IngestTap has a non nil tail")
+		return
+	}
+
+	cond1 := &condition{apiKey: "1"}
+	cond2 := &condition{apiKey: "2"}
+	cond3 := &condition{apiKey: "3"}
+	cond4 := &condition{apiKey: "4"}
+
+	tap.append(cond1)
+	tap.append(cond2)
+	tap.append(cond3)
+
+	tap.remove(cond4)
+
+	///////// Third item
+	if tap.head != cond1 {
+		t.Errorf("tap.head != cond1")
+		return
+	}
+	if nil != cond1.prevItem {
+		t.Errorf("nil != cond1.prevItem")
+		return
+	}
+	if cond1.nextItem != cond2 {
+		t.Errorf("cond1.nextItem != cond2")
+		return
+	}
+	if cond2.prevItem != cond1 {
+		t.Errorf("cond2.prevItem != cond1")
+		return
+	}
+	if cond2.nextItem != cond3 {
+		t.Errorf("cond2.nextItem != cond3")
+		return
+	}
+	if cond3.prevItem != cond2 {
+		t.Errorf("cond3.prevItem != cond2")
+		return
+	}
+	if cond3.nextItem != nil {
+		t.Errorf("cond3.nextItem != nil")
+		return
+	}
+
+}
+
+func TestLinkedListAddRemoveHead(t *testing.T) {
+	tap := IngestTap{}
+	if nil != tap.head {
+		t.Errorf("Zero value of IngestTap has a non nil head")
+		return
+	}
+	if nil != tap.tail {
+		t.Errorf("Zero value of IngestTap has a non nil tail")
+		return
+	}
+
+	cond1 := &condition{apiKey: "1"}
+	cond2 := &condition{apiKey: "2"}
+	cond3 := &condition{apiKey: "3"}
+
+	tap.append(cond1)
+	tap.append(cond2)
+	tap.append(cond3)
+
+	tap.remove(cond1)
+
+	if nil != cond1.nextItem || nil != cond1.prevItem {
+		t.Errorf("Failed to unset next/prev on cond1")
+		return
+	}
+
+	if cond2 != tap.head {
+		t.Errorf("After removal of head, cond2 should be tap.head")
+		return
+	}
+
+	if cond2.prevItem != nil {
+		t.Errorf("tap.head has a prev item")
+		return
+	}
+
+	if cond2.nextItem != cond3 {
+		t.Errorf("cond2.next item should be cond3")
+		return
+	}
+
+}
+
+func TestLinkedListAddRemoveMiddle(t *testing.T) {
+	tap := IngestTap{}
+	if nil != tap.head {
+		t.Errorf("Zero value of IngestTap has a non nil head")
+		return
+	}
+	if nil != tap.tail {
+		t.Errorf("Zero value of IngestTap has a non nil tail")
+		return
+	}
+
+	cond1 := &condition{apiKey: "1"}
+	cond2 := &condition{apiKey: "2"}
+	cond3 := &condition{apiKey: "3"}
+
+	tap.append(cond1)
+	tap.append(cond2)
+	tap.append(cond3)
+
+	tap.remove(cond2)
+
+	if nil != cond2.nextItem || nil != cond2.prevItem {
+		t.Errorf("Failed to unset next/prev on cond2")
+		return
+	}
+
+	if tap.head != cond1 {
+		t.Errorf("tap.head should be cond1")
+		return
+	}
+	if tap.tail != cond3 {
+		t.Errorf("tap.tail should be cond3")
+		return
+	}
+	if cond1.nextItem != cond3 {
+		t.Errorf("cond1.nextItem should be cond3")
+		return
+	}
+	if cond3.prevItem != cond1 {
+		t.Errorf("cond3.prevItem should be cond1")
+		return
+	}
+	if nil != cond3.nextItem {
+		t.Errorf("cond3.nextItem should be nil")
+		return
+	}
+	if nil != cond1.prevItem {
+		t.Errorf("cond1.prevItem should be nil")
+		return
+	}
+}
+
+func TestLinkedListAddRemoveTail(t *testing.T) {
+	tap := IngestTap{}
+	if nil != tap.head {
+		t.Errorf("Zero value of IngestTap has a non nil head")
+		return
+	}
+	if nil != tap.tail {
+		t.Errorf("Zero value of IngestTap has a non nil tail")
+		return
+	}
+
+	cond1 := &condition{apiKey: "1"}
+	cond2 := &condition{apiKey: "2"}
+	cond3 := &condition{apiKey: "3"}
+
+	tap.append(cond1)
+	tap.append(cond2)
+	tap.append(cond3)
+
+	tap.remove(cond3)
+
+	if nil != cond3.nextItem || nil != cond3.prevItem {
+		t.Errorf("Failed to unset next/prev on cond3")
+		return
+	}
+
+	if cond2 != tap.tail {
+		t.Errorf("tap.tail should be cond2")
+	}
+	if cond1 != tap.head {
+		t.Errorf("tap.head should be cond1")
+	}
+	if cond1.nextItem != cond2 {
+		t.Errorf("cond1.nextItem != cond2")
+	}
+	if cond2.prevItem != cond1 {
+		t.Errorf("cond2.prevItem != cond1")
+	}
+}

--- a/lib/sink/sink.go
+++ b/lib/sink/sink.go
@@ -49,6 +49,14 @@ func (s *Sink) Listen() chan tracker.Event {
 	return s.events
 }
 
+// Server pokes a hole in the abstraction to get to the nats server
+func (s *Sink) Server() any {
+	if ns, ok := s.dest.(*NatsSink); ok {
+		return ns.server
+	}
+	return nil
+}
+
 func (s *Sink) Stop() {
 	close(s.events)
 	s.config.Finish()

--- a/lib/tracker/input.go
+++ b/lib/tracker/input.go
@@ -58,7 +58,7 @@ type (
 	// Middleware has a chance to modify a frame before we send it to the plane Tracker
 	Middleware interface {
 		fmt.Stringer
-		Handle(Frame) Frame
+		Handle(*FrameEvent) Frame
 	}
 )
 
@@ -202,7 +202,7 @@ func (t *Tracker) decodeQueue() {
 		}
 
 		for _, m := range t.middlewares {
-			frame = m.Handle(frame)
+			frame = m.Handle(f)
 			if nil == frame {
 				break
 			}


### PR DESCRIPTION
Initial support for a new middleware to tap into the processing feed and capture raw messages and have them sent on the nats bus

Initial support for a client program to request either all frames from a specific feed (api-key) or specific icao from all feeds

With this I can start to narrow down beast frames causing us to see jumping planes.

Future work can include requesting the current list of API users (using the pw_atc_api nats endpoint) and displaying a choosable list of users to check out

As this is requestable over the nats bus, it can be requested by ATC and a summary maybe shown on the users dashboard?