### PR TITLE
include app ver in prometheus metrics 

### DIFF
--- a/cmd/pw_atc_api/main.go
+++ b/cmd/pw_atc_api/main.go
@@ -26,39 +26,55 @@ var (
 	version = "dev"
 	db      *sqlx.DB
 
+	ErrUnsupportedResponse = `{"error":"Unsupported Request","Type":"%s"}`
+	ErrRequestFailed       = `{"error":"Something went wrong with the request","Type":"%s"}`
+
 	prometheusCounterSearch = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_atc_api_search_count",
-		Help: "The number of searches handled",
+		Namespace: "pw_atc_api",
+		Name:      "search_count",
+		Help:      "The number of searches handled",
 	})
 
 	prometheusCounterSearchSummary = promauto.NewSummary(prometheus.SummaryOpts{
-		Name: "pw_atc_api_search_summary",
-		Help: "A Summary of the search times in milliseconds",
+		Namespace: "pw_atc_api",
+		Name:      "search_summary",
+		Help:      "A Summary of the search times in milliseconds",
 	})
 
 	prometheusCounterEnrich = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_atc_api_enrich_count",
-		Help: "The number of enrichments handled",
+		Namespace: "pw_atc_api",
+		Name:      "enrich_count",
+		Help:      "The number of enrichments handled",
 	})
 
 	prometheusCounterEnrichSummary = promauto.NewSummary(prometheus.SummaryOpts{
-		Name: "pw_atc_api_enrich_summary",
-		Help: "A Summary of the enrich times in milliseconds",
+		Namespace: "pw_atc_api",
+		Name:      "enrich_summary",
+		Help:      "A Summary of the enrich times in milliseconds",
 	})
 
 	prometheusCounterFeeder = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_atc_api_feeder_count",
-		Help: "The number of requests for feeder information and feeder updates",
+		Namespace: "pw_atc_api",
+		Name:      "feeder_count",
+		Help:      "The number of requests for feeder information and feeder updates",
 	})
 
 	prometheusCounterFeederSummary = promauto.NewSummary(prometheus.SummaryOpts{
-		Name: "pw_atc_api_feeder_summary",
-		Help: "A Summary of the feeder request times in milliseconds",
+		Namespace: "pw_atc_api",
+		Name:      "feeder_summary",
+		Help:      "A Summary of the feeder request times in milliseconds",
 	})
 
-	ErrUnsupportedResponse = `{"error":"Unsupported Request","Type":"%s"}`
-	ErrRequestFailed       = `{"error":"Something went wrong with the request","Type":"%s"}`
+	prometheusAppVer = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "pw_atc_api",
+		Name:      "info",
+		Help:      "Application Info/Metadata",
+	}, []string{"version"})
 )
+
+func init() {
+	prometheusAppVer.With(prometheus.Labels{"version": version}).Set(1)
+}
 
 func main() {
 	app := cli.NewApp()

--- a/cmd/pw_ingest/main.go
+++ b/cmd/pw_ingest/main.go
@@ -26,18 +26,30 @@ const (
 var (
 	version                        = "dev"
 	prometheusCounterFramesDecoded = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pw_ingest_num_decoded_frames",
-		Help: "The number of AVR frames decoded",
+		Namespace: "pw_ingest",
+		Name:      "num_decoded_frames",
+		Help:      "The number of AVR frames decoded",
 	})
 	prometheusGaugeCurrentPlanes = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pw_ingest_current_tracked_planes_count",
-		Help: "The number of planes this instance is currently tracking",
+		Namespace: "pw_ingest",
+		Name:      "current_tracked_planes_count",
+		Help:      "The number of planes this instance is currently tracking",
 	})
 	prometheusOutputFrameDedupe = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_ingest_output_frame_dedupe_total",
-		Help: "The total number of deduped frames not output.",
+		Namespace: "pw_ingest",
+		Name:      "output_frame_dedupe_total",
+		Help:      "The total number of deduped frames not output.",
 	})
+	prometheusAppVer = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "pw_ingest",
+		Name:      "info",
+		Help:      "Application Info/Metadata",
+	}, []string{"version"})
 )
+
+func init() {
+	prometheusAppVer.With(prometheus.Labels{"version": version}).Set(1)
+}
 
 func main() {
 	app := cli.NewApp()

--- a/cmd/pw_router/main.go
+++ b/cmd/pw_router/main.go
@@ -40,38 +40,55 @@ type (
 var (
 	version          = "dev"
 	updatesProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_updates_processed_total",
-		Help: "The total number of messages processed.",
+		Namespace: "pw_router",
+		Name:      "updates_processed_total",
+		Help:      "The total number of messages processed.",
 	})
 	updatesSignificant = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_updates_significant_total",
-		Help: "The total number of messages determined to be significant.",
+		Namespace: "pw_router",
+		Name:      "updates_significant_total",
+		Help:      "The total number of messages determined to be significant.",
 	})
 	updatesInsignificant = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_updates_insignificant_total",
-		Help: "The total number of messages determined to be insignificant.",
+		Namespace: "pw_router",
+		Name:      "updates_insignificant_total",
+		Help:      "The total number of messages determined to be insignificant.",
 	})
 	updatesIgnored = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_updates_ignored_total",
-		Help: "The total number of messages determined to be insignificant and thus ignored.",
+		Namespace: "pw_router",
+		Name:      "updates_ignored_total",
+		Help:      "The total number of messages determined to be insignificant and thus ignored.",
 	})
 	updatesPublished = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_updates_published_total",
-		Help: "The total number of messages published to the output queue.",
+		Namespace: "pw_router",
+		Name:      "updates_published_total",
+		Help:      "The total number of messages published to the output queue.",
 	})
 	updatesError = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_updates_error_total",
-		Help: "The total number of messages that could not be processed due to an error.",
+		Namespace: "pw_router",
+		Name:      "updates_error_total",
+		Help:      "The total number of messages that could not be processed due to an error.",
 	})
 	cacheEntries = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pw_router_cache_planes_count",
-		Help: "The number of planes in the reducer cache.",
+		Namespace: "pw_router",
+		Name:      "cache_planes_count",
+		Help:      "The number of planes in the reducer cache.",
 	})
 	cacheEvictions = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pw_router_cache_eviction_total",
-		Help: "The number of cache evictions made from the cache.",
+		Namespace: "pw_router",
+		Name:      "cache_eviction_total",
+		Help:      "The number of cache evictions made from the cache.",
 	})
+	prometheusAppVer = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "pw_router",
+		Name:      "info",
+		Help:      "Application Info/Metadata",
+	}, []string{"version"})
 )
+
+func init() {
+	prometheusAppVer.With(prometheus.Labels{"version": version}).Set(1)
+}
 
 func main() {
 	app := cli.NewApp()

--- a/cmd/pw_ws_broker/main.go
+++ b/cmd/pw_ws_broker/main.go
@@ -18,42 +18,51 @@ var (
 	version = "dev"
 
 	prometheusNumClients = promauto.NewGauge(prometheus.GaugeOpts{
-		Subsystem: "pw_ws_broker",
+		Namespace: "pw_ws_broker",
 		Name:      "num_clients",
 		Help:      "The current number of websocket clients we are currently serving",
 	})
 	prometheusIncomingMessages = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: "pw_ws_broker",
+			Namespace: "pw_ws_broker",
 			Name:      "incoming_messages",
 			Help:      "The number of messages from the queue",
 		},
 		[]string{"rate"},
 	)
 	prometheusKnownPlanes = promauto.NewGauge(prometheus.GaugeOpts{
-		Subsystem: "pw_ws_broker",
+		Namespace: "pw_ws_broker",
 		Name:      "known_planes",
 		Help:      "The number of planes we know about",
 	})
 	prometheusMessagesSent = promauto.NewCounter(prometheus.CounterOpts{
-		Subsystem: "pw_ws_broker",
+		Namespace: "pw_ws_broker",
 		Name:      "messages_sent",
 		Help:      "The number of messages sent to clients over websockets",
 	})
 	prometheusMessagesSize = promauto.NewCounter(prometheus.CounterOpts{
-		Subsystem: "pw_ws_broker",
+		Namespace: "pw_ws_broker",
 		Name:      "messages_size",
 		Help:      "the raw size of messages sent (before compression)",
 	})
 	prometheusSubscriptions = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: "pw_ws_broker",
+			Namespace: "pw_ws_broker",
 			Name:      "subscriptions",
 			Help:      "which tiles people are subscribed to",
 		},
 		[]string{"tile"},
 	)
+	prometheusAppVer = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "pw_ws_broker",
+		Name:      "info",
+		Help:      "Application Info/Metadata",
+	}, []string{"version"})
 )
+
+func init() {
+	prometheusAppVer.With(prometheus.Labels{"version": version}).Set(1)
+}
 
 func main() {
 	app := cli.NewApp()


### PR DESCRIPTION
for pw_ingest, pw_router, pw_ws_broker, and pw_atc_api

this is so we can graph the versions of the apps.

I think I have gotten this right according to some best practice stuff

https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels