### PR TITLE
Add support for "feeder_code" in pw_atc_api for v1.feeder.list

### DIFF
--- a/cmd/pw_atc_api/feeders.go
+++ b/cmd/pw_atc_api/feeders.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/nats-io/nats.go"
 	"plane.watch/lib/export"
-	"time"
 )
 
 type (
@@ -61,6 +62,7 @@ SELECT
 	f.feed_protocol,
 	f.label,
 	f.mlat_enabled,
+	f.feeder_code,
 	concat('mux-#', LOWER(fm.name)) as container_name
 FROM feeders f
     LEFT JOIN users u on f.user_id = u.id

--- a/lib/export/nats_api.go
+++ b/lib/export/nats_api.go
@@ -1,8 +1,9 @@
 package export
 
 import (
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -77,6 +78,7 @@ type (
 		Label         string    `db:"label"`
 		MlatEnabled   bool      `db:"mlat_enabled"`
 		Mux           string    `db:"container_name"`
+		FeederCode    string    `db:"feeder_code"`
 	}
 
 	FeederUpdates []FeederUpdate


### PR DESCRIPTION
`feeder_code` was recently added to the feeder schema in ATC.

See: https://github.com/plane-watch/pw-air_traffic_control/blob/7c13a1ec609268792e9630d54597de263de14787/db/schema.rb#L83.

This PR should hopefully add support for it.

Currently untested.