### PR TITLE
Attempt to fix panic in pw_router

### DIFF
--- a/cmd/ingest_tap/planewatch.go
+++ b/cmd/ingest_tap/planewatch.go
@@ -3,16 +3,18 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"plane.watch/lib/export"
 	"plane.watch/lib/middleware"
 	"plane.watch/lib/nats_io"
 	"plane.watch/lib/randstr"
 	"plane.watch/lib/sink"
 	"plane.watch/lib/ws_protocol"
-	"sync"
-	"time"
 )
 
 const (
@@ -188,6 +190,7 @@ func (pw *PlaneWatchTapper) natsTap(icao, feederKey string, subject string, call
 		for {
 			select {
 			case msg := <-ch:
+				log.Info().Any("msg", string(msg.Data)).Msg("Received natsTap message")
 				var planeLocation export.PlaneLocation
 				err = json.Unmarshal(msg.Data, &planeLocation)
 				if nil != err {
@@ -279,7 +282,10 @@ func (pw *PlaneWatchTapper) maybeSend(ff *wsFilterFunc, loc *export.PlaneLocatio
 		return
 	}
 	if ff.feederTag != "" {
-		if _, ok := loc.SourceTags[ff.feederTag]; !ok {
+		loc.SourceTagsMutex.RLock()
+		_, ok := loc.SourceTags[ff.feederTag]
+		loc.SourceTagsMutex.RUnlock()
+		if !ok {
 			return
 		}
 	}

--- a/cmd/ingest_tap/tui.go
+++ b/cmd/ingest_tap/tui.go
@@ -268,6 +268,7 @@ func (m *model) updateAircraftTable() {
 	var p *export.PlaneLocation
 	for _, icaoStr := range data.icaos {
 		p = data.planes[icaoStr]
+		p.SourceTagsMutex.RLock()
 		rows = append(rows, table.Row{
 			icaoStr,
 			strconv.Itoa(len(p.SourceTags)),
@@ -279,6 +280,7 @@ func (m *model) updateAircraftTable() {
 			p.VerticalRateStr(),
 			p.HeadingStr(),
 		})
+		p.SourceTagsMutex.RUnlock()
 	}
 	m.planesTable.SetRows(rows)
 }

--- a/cmd/pw_router/worker.go
+++ b/cmd/pw_router/worker.go
@@ -206,10 +206,12 @@ func (w *worker) handleMsg(msg []byte) error {
 
 	// if this Icao is not in the cache, it's new.
 	if !ok {
+		update.SourceTagsMutex.Lock()
 		if nil == update.SourceTags {
 			update.SourceTags = make(map[string]uint32)
 		}
 		update.SourceTags[update.SourceTag]++
+		update.SourceTagsMutex.Unlock()
 		w.router.syncSamples.Store(update.Icao, update)
 
 		w.handleNewUpdate(update, msg)

--- a/lib/export/location.go
+++ b/lib/export/location.go
@@ -55,15 +55,15 @@ func NewPlaneLocation(plane *tracker.Plane, isNew, isRemoved bool, source string
 			Special:      plane.SpecialUpdatedAt().UTC(),
 			Squawk:       plane.SquawkUpdatedAt().UTC(),
 		},
-		sourceTagsMutex: &sync.Mutex{},
+		SourceTagsMutex: &sync.RWMutex{},
 	}
 }
 
 func (pl *PlaneLocation) ToJSONBytes() ([]byte, error) {
 	json := jsoniter.ConfigFastest
 
-	pl.sourceTagsMutex.Lock()
-	defer pl.sourceTagsMutex.Unlock()
+	pl.SourceTagsMutex.Lock()
+	defer pl.SourceTagsMutex.Unlock()
 
 	jsonBuf, err := json.Marshal(pl)
 	if nil != err {

--- a/lib/export/types.go
+++ b/lib/export/types.go
@@ -55,7 +55,7 @@ type (
 		TileLocation    string
 
 		SourceTags      map[string]uint32 `json:",omitempty"`
-		sourceTagsMutex *sync.Mutex
+		SourceTagsMutex *sync.RWMutex
 
 		// TrackedSince is when we first started tracking this aircraft *this time*
 		TrackedSince time.Time
@@ -113,8 +113,8 @@ func (pl *PlaneLocation) Plane() string {
 }
 
 func (pl *PlaneLocation) CloneSourceTags() map[string]uint32 {
-	pl.sourceTagsMutex.Lock()
-	defer pl.sourceTagsMutex.Unlock()
+	pl.SourceTagsMutex.RLock()
+	defer pl.SourceTagsMutex.RUnlock()
 
 	return Clone(pl.SourceTags)
 }
@@ -123,8 +123,8 @@ func (pl *PlaneLocation) CloneSourceTags() map[string]uint32 {
 // YPPH-0001 -> 0001
 // YPAD-12345 -> 12345
 func (pl *PlaneLocation) PrepareSourceTags(m map[string]uint32) map[string]uint32 {
-	pl.sourceTagsMutex.Lock()
-	defer pl.sourceTagsMutex.Unlock()
+	pl.SourceTagsMutex.RLock()
+	defer pl.SourceTagsMutex.RUnlock()
 	var sk string
 	for k, v := range pl.SourceTags {
 		// allow up to 7 numbers
@@ -173,15 +173,15 @@ func MergePlaneLocations(prev, next PlaneLocation) (PlaneLocation, error) {
 	merged.Removed = false
 	merged.LastMsg = next.LastMsg
 	merged.SignalRssi = nil // makes no sense to merge this value as it is for the individual receiver
-	if nil == merged.sourceTagsMutex {
-		merged.sourceTagsMutex = &sync.Mutex{}
+	if nil == merged.SourceTagsMutex {
+		merged.SourceTagsMutex = &sync.RWMutex{}
 	}
-	merged.sourceTagsMutex.Lock()
+	merged.SourceTagsMutex.Lock()
 	if nil == merged.SourceTags {
 		merged.SourceTags = make(map[string]uint32)
 	}
 	merged.SourceTags[next.SourceTag]++
-	merged.sourceTagsMutex.Unlock()
+	merged.SourceTagsMutex.Unlock()
 
 	if next.TrackedSince.Before(prev.TrackedSince) {
 		merged.TrackedSince = next.TrackedSince

--- a/lib/export/types_test.go
+++ b/lib/export/types_test.go
@@ -171,7 +171,7 @@ func TestPlaneLocation_PrepareSourceTags(t *testing.T) {
 				SourceTags: map[string]uint32{
 					tt.fields: 1,
 				},
-				sourceTagsMutex: &sync.Mutex{},
+				SourceTagsMutex: &sync.RWMutex{},
 			}
 			if got := pl.PrepareSourceTags(m); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("PrepareSourceTags() = %v, want %v", got, tt.want)


### PR DESCRIPTION
- Make PlaneLocation.SourceTagsMutex exported
- Change to RWMutex
- Wrap all read accesses to PlaneLocation.SourceTags in RLock/RUnlock.
- Wrap all write accesses to PlaneLocation.SourceTags in Lock/Unlock.

Resolves #269 (hopefully).