### PR TITLE
fix: ensure we init the source tags mutex properly.

### DIFF
--- a/cmd/pw_router/worker.go
+++ b/cmd/pw_router/worker.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
+	"math"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog/log"
-	"math"
 	"plane.watch/lib/export"
 )
 
@@ -206,10 +207,8 @@ func (w *worker) handleMsg(msg []byte) error {
 
 	// if this Icao is not in the cache, it's new.
 	if !ok {
-		if nil == update.SourceTags {
-			update.SourceTags = make(map[string]uint32)
-		}
-		update.SourceTags[update.SourceTag]++
+		update.InitSourceTags()
+		update.IncSourceTag(update.SourceTag)
 		w.router.syncSamples.Store(update.Icao, update)
 
 		w.handleNewUpdate(update, msg)

--- a/lib/export/types.go
+++ b/lib/export/types.go
@@ -138,6 +138,23 @@ func (pl *PlaneLocation) PrepareSourceTags(m map[string]uint32) map[string]uint3
 	return m
 }
 
+func (pl *PlaneLocation) InitSourceTags() {
+	if nil == pl.sourceTagsMutex {
+		pl.sourceTagsMutex = &sync.Mutex{}
+	}
+	pl.sourceTagsMutex.Lock()
+	defer pl.sourceTagsMutex.Unlock()
+	if nil == pl.SourceTags {
+		pl.SourceTags = make(map[string]uint32)
+	}
+}
+
+func (pl *PlaneLocation) IncSourceTag(key string) {
+	pl.sourceTagsMutex.Lock()
+	defer pl.sourceTagsMutex.Unlock()
+	pl.SourceTags[key]++
+}
+
 // Clone returns a copy of m.  This is a shallow clone:
 // the new keys and values are set using ordinary assignment.
 func Clone[M ~map[K]V, K comparable, V any](m M) M {


### PR DESCRIPTION
this race condition can appear when we get 2 feeders getting a new plane and feeding them into the pipeline at the same time.

we were not initialising the plane location mutex properly when we go a new plane, so the sequence of events might be

1. feeder A sends in new plane
2. feeder B sends in new plane
3. pw-router worker 1 gets plane update from feeder A and stores it (nil sourceTagsMutex)
4. pw-router worker 2 gets plane update from feeder B and loads it (nil sourceTagsMutex)
5. pw-router merges, but needs to assign a mutex, assigns sourceTagsMutex
6. pw-router worker 1 publishes an update and access the map concurrently

we now have a pointer to a map protected by 2 different mutexes

Refs: #269