### PR TITLE
Connection handling improvements

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.4'
+          go-version: '1.25.5'
           check-latest: true
       - name: go vet
         run: go vet ./...

--- a/cmd/runway/customs.go
+++ b/cmd/runway/customs.go
@@ -138,6 +138,16 @@ func ListenForIncomingPlaneWatchBeast(ctx context.Context, opts ...Option) (*Man
 	return manifest, nil
 }
 
+// Close releases resources owned by the listener manifest.
+func (m *Manifest) Close() {
+	if m == nil {
+		return
+	}
+	if m.natsServer != nil {
+		m.natsServer.Close()
+	}
+}
+
 func (m *Manifest) authenticator(apiKey string) (bool, error) {
 	return m.feeders.Authenticate(apiKey, feederauth.BEAST)
 }

--- a/cmd/runway/customs.go
+++ b/cmd/runway/customs.go
@@ -127,6 +127,9 @@ func ListenForIncomingPlaneWatchBeast(ctx context.Context, opts ...Option) (*Man
 		stunnel.WithAuthenticator(manifest.authenticator),
 	)
 	if err != nil {
+		if manifest.natsServer != nil {
+			manifest.natsServer.Close()
+		}
 		return nil, fmt.Errorf("failed to setup stunnel listener: %w", err)
 	}
 
@@ -174,6 +177,7 @@ func (m *Manifest) handler(conn net.Conn, apiKey string) error {
 	})
 	err = prometheus.Register(prometheusInputBeastFrames)
 	if err != nil {
+		m.feeders.SetDisconnected(apiKey, feederauth.BEAST)
 		return fmt.Errorf("failed to register prometheus counter: %w", err)
 	}
 	prometheusConnectedBeastFeeders.Inc()

--- a/cmd/runway/main.go
+++ b/cmd/runway/main.go
@@ -197,7 +197,7 @@ func runDaemon(c *cli.Context) error {
 	// BEAST Listener
 	wg.Go(func() {
 		defer cancel()
-		_, err := ListenForIncomingPlaneWatchBeast(
+		manifest, err := ListenForIncomingPlaneWatchBeast(
 			ctx,
 			WithListenHostPort(c.String("listen-beast")),
 			WithTLSCertificate(c.String("cert"), c.String("key")),
@@ -205,6 +205,9 @@ func runDaemon(c *cli.Context) error {
 			WithNatsURL(c.String("sink")),
 			WithFeederAuthenticator(feederAuthenticator),
 		)
+		if manifest != nil {
+			manifest.Close()
+		}
 		if err != nil {
 			log.Error().Err(err).Msg("failed to listen for beast")
 		}
@@ -213,13 +216,16 @@ func runDaemon(c *cli.Context) error {
 	// MLAT Listener
 	wg.Go(func() {
 		defer cancel()
-		_, err := mlatbridge.ListenForIncomingPlaneWatchMLAT(
+		mb, err := mlatbridge.ListenForIncomingPlaneWatchMLAT(
 			ctx,
 			mlatbridge.WithListenHostPort(c.String("listen-mlat")),
 			mlatbridge.WithTLSCertificate(c.String("cert"), c.String("key")),
 			mlatbridge.WithNatsURL(c.String("sink")),
 			mlatbridge.WithFeederAuthenticator(feederAuthenticator),
 		)
+		if mb != nil {
+			mb.Close()
+		}
 		if err != nil {
 			log.Error().Err(err).Msg("failed to listen for mlat")
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module plane.watch
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/coder/websocket v1.8.14

--- a/lib/feederauth/feedercache.go
+++ b/lib/feederauth/feedercache.go
@@ -218,7 +218,12 @@ func (f *FeederCache) Authenticate(apiKey string, p Protocol) (bool, error) {
 
 func (f *FeederCache) Close() error {
 	if f != nil {
-		f.refresherCancelFunc()
+		if f.refresherCancelFunc != nil {
+			f.refresherCancelFunc()
+		}
+		if f.natsServer != nil {
+			f.natsServer.Close()
+		}
 	}
 	return nil
 }

--- a/lib/mlatbridge/mlatbridge.go
+++ b/lib/mlatbridge/mlatbridge.go
@@ -129,6 +129,16 @@ func ListenForIncomingPlaneWatchMLAT(ctx context.Context, opts ...Option) (*MLAT
 	return mb, nil
 }
 
+// Close releases resources owned by the MLAT bridge.
+func (mb *MLATBridge) Close() {
+	if mb == nil {
+		return
+	}
+	if mb.natsServer != nil {
+		mb.natsServer.Close()
+	}
+}
+
 func (mb *MLATBridge) authenticator(apiKey string) (bool, error) {
 	return mb.feeders.Authenticate(apiKey, feederauth.MLAT)
 }
@@ -256,14 +266,6 @@ func (mb *MLATBridge) simplexBridge(ctx context.Context, cancel context.CancelFu
 		err  error
 		m, n int
 	)
-
-	// close both sides of the bridge when done
-	defer func() {
-		_ = from.Close()
-	}()
-	defer func() {
-		_ = to.Close()
-	}()
 
 	// make buffer to hold data in flight
 	buf := make([]byte, 64*1024) // 64KiB is a good general-purpose size

--- a/lib/mlatbridge/mlatbridge_test.go
+++ b/lib/mlatbridge/mlatbridge_test.go
@@ -1,0 +1,47 @@
+package mlatbridge
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+type trackingConn struct {
+	net.Conn
+	closed int32
+}
+
+func (c *trackingConn) Close() error {
+	atomic.AddInt32(&c.closed, 1)
+	return c.Conn.Close()
+}
+
+func TestSimplexBridgeDoesNotCloseConnections(t *testing.T) {
+	mb := &MLATBridge{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rawA, rawB := net.Pipe()
+	connA := &trackingConn{Conn: rawA}
+	connB := &trackingConn{Conn: rawB}
+
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_mlat_bridge_bytes_total",
+		Help: "test counter",
+	})
+
+	err := mb.simplexBridge(ctx, cancel, connA, connB, counter)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+	require.Equal(t, int32(0), atomic.LoadInt32(&connA.closed))
+	require.Equal(t, int32(0), atomic.LoadInt32(&connB.closed))
+
+	_ = connA.Close()
+	_ = connB.Close()
+}

--- a/lib/producer/common.go
+++ b/lib/producer/common.go
@@ -81,7 +81,7 @@ func New(opts ...Option) *Producer {
 			VelocityCheck:    true,
 		},
 		out:     make(chan tracker.FrameEvent, 100),
-		cmdChan: make(chan int),
+		cmdChan: make(chan int, 1),
 		run: func() {
 			println("You did not specify any sources")
 			os.Exit(1) // TODO(mikenye): something more graceful?
@@ -235,23 +235,31 @@ func WithConnection(conn net.Conn) Option {
 		p.FrameSource.OriginIdentifier = conn.RemoteAddr().String()
 		p.run = func() {
 			p.addInfo("Fetching From Host: %s", p.FrameSource.OriginIdentifier)
+			done := make(chan struct{})
 			go func() {
-				defer p.Cleanup()
-
-				defer func() {
-					p.log.Debug().Msg("closing connection")
-					_ = conn.Close()
-				}()
-
-				scan := bufio.NewScanner(conn)
-				p.log.Debug().Msg("start reading from scanner")
-				errRead := p.readFromScanner(scan)
-				if errRead != nil {
-					p.log.Error().Err(errRead).Msg("error reading from scanner")
+				select {
+				case cmd := <-p.cmdChan:
+					if cmd == cmdExit {
+						_ = conn.Close()
+					}
+				case <-done:
 				}
-				_ = conn.Close()
-				p.log.Debug().Msg("finish reading from scanner")
 			}()
+
+			defer func() {
+				close(done)
+				p.log.Debug().Msg("closing connection")
+				_ = conn.Close()
+				p.Cleanup()
+			}()
+
+			scan := bufio.NewScanner(conn)
+			p.log.Debug().Msg("start reading from scanner")
+			errRead := p.readFromScanner(scan)
+			if errRead != nil && !errors.Is(errRead, net.ErrClosed) && !errors.Is(errRead, io.EOF) {
+				p.log.Error().Err(errRead).Msg("error reading from scanner")
+			}
+			p.log.Debug().Msg("finish reading from scanner")
 		}
 	}
 }
@@ -409,7 +417,10 @@ func (p *Producer) HealthCheckName() string {
 }
 
 func (p *Producer) Stop() {
-	p.cmdChan <- cmdExit
+	select {
+	case p.cmdChan <- cmdExit:
+	default:
+	}
 }
 
 func (p *Producer) AddEvent(e tracker.FrameEvent) {


### PR DESCRIPTION
Full disclosure: these changes were done by `gpt-5.2-codex` `xhigh` model.

Prompt:

› can you please review cmd/runway for memory leaks and let me know where any are?

It's findings:

  - High: The poison-pill path calls p.Stop() for a producer.WithConnection producer; Stop() blocks because WithConnection never consumes cmdChan, so the ticker goroutine hangs and cleanup tasks (Unregister + SetDisconnected) never run, leaving per-connection metrics/state in memory. cmd/runway/customs.go:181, cmd/runway/customs.go:188, lib/producer/common.go:241, lib/producer/common.go:411
  - Medium: If stunnel.NewListener fails after creating the NATS server, the function returns without closing the NATS connection, leaking its goroutines/FDs. cmd/runway/customs.go:112, cmd/runway/customs.go:123
  - Low: SetConnected happens before Prometheus registration; if registration fails you return without SetDisconnected, leaving a stale feedersConnected entry in memory. cmd/runway/customs.go:161, cmd/runway/customs.go:175
