### PR TITLE
fix: use valid prometheus metric name for feeders_connected gauge

### DIFF
--- a/cmd/runway/customs.go
+++ b/cmd/runway/customs.go
@@ -50,7 +50,7 @@ var (
 	prometheusConnectedBeastFeeders = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "runway",
 		Subsystem: "beast",
-		Name:      "feeders-connected",
+		Name:      "feeders_connected",
 		Help:      "The total number of beast feeders connected.",
 	})
 )

--- a/docs/mlatbridge/README.md
+++ b/docs/mlatbridge/README.md
@@ -317,7 +317,7 @@ for written < n {
 prometheusConnectedMLATFeeders = promauto.NewGauge(prometheus.GaugeOpts{
     Namespace: "runway",
     Subsystem: "mlat",
-    Name:      "feeders-connected",
+    Name:      "feeders_connected",
     Help:      "The total number of mlat feeders connected.",
 })
 ```

--- a/lib/mlatbridge/mlatbridge.go
+++ b/lib/mlatbridge/mlatbridge.go
@@ -50,7 +50,7 @@ var (
 	prometheusConnectedMLATFeeders = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "runway",
 		Subsystem: "mlat",
-		Name:      "feeders-connected",
+		Name:      "feeders_connected",
 		Help:      "The total number of mlat feeders connected.",
 	})
 )


### PR DESCRIPTION
## Summary
      - Replace invalid `feeders-connected` prometheus metric name with `feeders_connected` in the runway beast and mlatbridge gauges
      - Prometheus metric names must match `[a-zA-Z_:][a-zA-Z0-9_:]*` — hyphens are invalid and cause registration to panic
      - Also updates the matching code snippet in `docs/mlatbridge/README.md` to stay in sync

