### PR TITLE
fix(router): make merge updates atomic per ICAO

### DIFF
--- a/cmd/pw_router/main.go
+++ b/cmd/pw_router/main.go
@@ -25,9 +25,22 @@ const (
 	qSuffixHigh = "_high"
 )
 
+// icaoLock is a per-ICAO mutex that protects the Load-Merge-Store sequence
+// in the worker's handleMsg path. Entries are never removed, so the map
+// grows monotonically with distinct ICAOs seen over the process lifetime.
+// In practice this is bounded by the ~18-bit ICAO address space and the
+// subset of aircraft that are ever observed.
+type icaoLock struct {
+	mu sync.Mutex
+}
+
 type (
 	pwRouter struct {
 		syncSamples *forgetfulmap.ForgetfulSyncMap
+
+		// icaoLocks provides per-ICAO mutual exclusion so that the
+		// Load → Merge → Store sequence in handleMsg is atomic.
+		icaoLocks sync.Map // map[string]*icaoLock
 
 		haveSourceSinkConnection bool
 

--- a/cmd/pw_router/main.go
+++ b/cmd/pw_router/main.go
@@ -267,7 +267,7 @@ func run(c *cli.Context) error {
 		// and then close all the things
 		cancel()
 	}()
-	monitoring.AddHealthCheck(router)
+	monitoring.AddHealthCheck(&router)
 
 	numWorkers := c.Int("num-workers")
 	destRouteKeyLow := c.String("destination-route-key")
@@ -295,11 +295,11 @@ func run(c *cli.Context) error {
 	return nil
 }
 
-func (p pwRouter) HealthCheckName() string {
+func (p *pwRouter) HealthCheckName() string {
 	return "pw_router"
 }
 
-func (p pwRouter) HealthCheck() bool {
+func (p *pwRouter) HealthCheck() bool {
 	// let's do a chan checks
 
 	l := len(p.incomingMessages)

--- a/cmd/pw_router/worker.go
+++ b/cmd/pw_router/worker.go
@@ -202,19 +202,6 @@ func (w *worker) handleMsg(msg []byte) error {
 
 	updatesProcessed.Inc()
 
-	// lookup what we know about this plane.
-	item, ok := w.router.syncSamples.Load(update.Icao)
-
-	// if this Icao is not in the cache, it's new.
-	if !ok {
-		update.InitSourceTags()
-		update.IncSourceTag(update.SourceTag)
-		w.router.syncSamples.Store(update.Icao, update)
-
-		w.handleNewUpdate(update, msg)
-		return nil // finish here, no significance check as we have nothing to compare.
-	}
-
 	// upstream signals that this plane has been removed / lost.
 	if update.Removed {
 		// TODO: we need to do our own reaping, since we can have multiple upstreams and one upstream losing track of
@@ -223,13 +210,34 @@ func (w *worker) handleMsg(msg []byte) error {
 		return nil // don't need to do anything else with this.
 	}
 
+	// Acquire per-ICAO lock so the Load → Merge → Store is atomic.
+	lk, _ := w.router.icaoLocks.LoadOrStore(update.Icao, &icaoLock{})
+	il := lk.(*icaoLock)
+	il.mu.Lock()
+
+	// lookup what we know about this plane.
+	item, ok := w.router.syncSamples.Load(update.Icao)
+
+	// if this Icao is not in the cache, it's new.
+	if !ok {
+		update.InitSourceTags()
+		update.IncSourceTag(update.SourceTag)
+		w.router.syncSamples.Store(update.Icao, update)
+		il.mu.Unlock()
+
+		w.handleNewUpdate(update, msg)
+		return nil // finish here, no significance check as we have nothing to compare.
+	}
+
 	// is this update significant versus the previous one
 	lastRecord := item.(export.PlaneLocation)
 	merged, err := export.MergePlaneLocations(lastRecord, update)
 	if nil != err {
+		il.mu.Unlock()
 		return nil
 	}
 	w.router.syncSamples.Store(merged.Icao, merged)
+	il.mu.Unlock()
 
 	mergedMsg, err := merged.ToJSONBytes()
 	if nil != err {

--- a/lib/export/types.go
+++ b/lib/export/types.go
@@ -213,7 +213,7 @@ func MergePlaneLocations(prev, next PlaneLocation) (PlaneLocation, error) {
 	}
 	if next.HasHeading && next.Updates.Heading.After(prev.Updates.Heading) {
 		merged.Heading = next.Heading
-		merged.Updates.Heading = prev.Updates.Heading
+		merged.Updates.Heading = next.Updates.Heading
 		merged.HasHeading = true
 	}
 	if next.HasVelocity && next.Updates.Velocity.After(prev.Updates.Velocity) {

--- a/lib/export/types_test.go
+++ b/lib/export/types_test.go
@@ -130,6 +130,62 @@ func TestMergeCallSign(t *testing.T) {
 	}
 }
 
+func TestMergeHeadingTimestampAdvances(t *testing.T) {
+	t1 := time.Date(2023, time.January, 9, 19, 0, 0, 0, time.UTC)
+	t2 := time.Date(2023, time.January, 9, 19, 0, 1, 0, time.UTC)
+
+	prev := PlaneLocation{
+		HasHeading: true,
+		Heading:    90.0,
+		Updates:    Updates{Heading: t1},
+	}
+	next := PlaneLocation{
+		HasHeading: true,
+		Heading:    180.0,
+		Updates:    Updates{Heading: t2},
+	}
+
+	merged, err := MergePlaneLocations(prev, next)
+	if err != nil {
+		t.Fatalf("MergePlaneLocations() error = %v", err)
+	}
+
+	if merged.Heading != 180.0 {
+		t.Errorf("expected heading 180.0, got %f", merged.Heading)
+	}
+	if !merged.Updates.Heading.Equal(t2) {
+		t.Errorf("expected heading timestamp to advance to t2 (%v), got %v", t2, merged.Updates.Heading)
+	}
+}
+
+func TestMergeHeadingTimestampRejectsStale(t *testing.T) {
+	t1 := time.Date(2023, time.January, 9, 19, 0, 1, 0, time.UTC)
+	t2 := time.Date(2023, time.January, 9, 19, 0, 0, 0, time.UTC)
+
+	prev := PlaneLocation{
+		HasHeading: true,
+		Heading:    90.0,
+		Updates:    Updates{Heading: t1},
+	}
+	next := PlaneLocation{
+		HasHeading: true,
+		Heading:    180.0,
+		Updates:    Updates{Heading: t2},
+	}
+
+	merged, err := MergePlaneLocations(prev, next)
+	if err != nil {
+		t.Fatalf("MergePlaneLocations() error = %v", err)
+	}
+
+	if merged.Heading != 90.0 {
+		t.Errorf("expected stale heading to be rejected, got %f", merged.Heading)
+	}
+	if !merged.Updates.Heading.Equal(t1) {
+		t.Errorf("expected heading timestamp to stay at t1 (%v), got %v", t1, merged.Updates.Heading)
+	}
+}
+
 func TestPlaneLocation_PrepareSourceTags(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary
- fix the heading timestamp merge bug in `MergePlaneLocations`
- make the router `Load -> Merge -> Store` path atomic per ICAO using per-aircraft locks
- add tests covering heading timestamp advancement and stale heading rejection

## Why
Under load, the router could merge two updates against the same cached snapshot and let one write clobber the other. Separately, heading timestamps were not being advanced correctly during merges, which weakened stale-heading protection.

## Testing
- `go test ./lib/export ./cmd/pw_router`
